### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -8,7 +8,7 @@
     "depends"       : [ ],
     "provides"      : { "Unicode::UTF8-Parser" : "lib/Unicode/UTF8-Parser.pm6"},
     "repo-type"     : "git",
-    "license"       : "http://www.perlfoundation.org/artistic_license_2_0",
+    "license"       : "Artistic-2.0",
     "source-url"    : "git://github.com/krunen/unicode-utf8-parser.git",
     "support"       : {
         "irc" : "irc://irc.freenode.org/#perl6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license